### PR TITLE
test: Added test script for control type "Color"

### DIFF
--- a/cypress/integration/control_color.js
+++ b/cypress/integration/control_color.js
@@ -69,7 +69,7 @@ context('Control Color', () => {
 		});
 
 		//Clearing the field and checking if the field contains the placeholder "Choose a color"
-		cy.get_field('color','Color').click({force: true});
+		cy.get('.input-with-feedback').click({force: true});
 		cy.get_field('color','Color').type('{selectall}').clear();
 		cy.get_field('color','Color').invoke('attr', 'placeholder').should('contain', 'Choose a color');
 

--- a/cypress/integration/control_color.js
+++ b/cypress/integration/control_color.js
@@ -1,0 +1,77 @@
+context('Control Color', () => {
+	before(() => {
+		cy.login();
+		cy.visit('/app/website');
+	});
+
+	function get_dialog_with_color() {
+		return cy.dialog({
+			title: 'Color',
+			fields: [{
+				label: 'Color',
+				fieldname: 'color',
+				fieldtype: 'Color'
+			}]
+		});
+	}
+
+	it('Verifying if the color control is selecting correct', () => {
+		get_dialog_with_color().as('dialog');
+		cy.findByPlaceholderText('Choose a color').click();
+
+		///Selecting a color from the color palette
+		cy.get('[style="background-color: rgb(79, 157, 217);"]').click();
+
+		//Checking if the css attribute is correct
+		cy.get('.color-map').should('have.css','color','rgb(79, 157, 217)');
+		cy.get('.hue-map').should('have.css','color','rgb(0, 145, 255)');
+
+		//Checking if the correct color is being selected
+		cy.get('@dialog').then(dialog => {
+		let value = dialog.get_value('color');
+		expect(value).to.equal('#4F9DD9')
+		});
+
+		//Selecting a color
+		cy.get('[style="background-color: rgb(203, 41, 41);"]').click();
+
+		//Checking if the correct css is being selected
+		cy.get('.color-map').should('have.css','color','rgb(203, 41, 41)');
+		cy.get('.hue-map').should('have.css','color','rgb(255, 0, 0)');
+
+		//Checking if the correct color is being selected
+		cy.get('@dialog').then(dialog => {
+		let value = dialog.get_value('color');
+		expect(value).to.equal('#CB2929')
+		});
+
+		//Selecting color from the palette
+		cy.get('.color-map > .color-selector').click(65, 87, {force: true});
+		cy.get('.color-map').should('have.css','color','rgb(56, 0, 0)');
+
+		//Checking if the expected color is selected and getting displayed
+		cy.get('@dialog').then(dialog => {
+		let value = dialog.get_value('color');
+		expect(value).to.equal('#380000')
+		});
+
+		//Selecting the color from the hue map
+		cy.get('.hue-map > .hue-selector').click(35, -1, {force: true});
+		cy.get('.color-map').should('have.css','color', 'rgb(56, 45, 0)');
+		cy.get('.hue-map').should('have.css','color','rgb(255, 204, 0)');
+		cy.get('.color-map > .color-selector').click(55, 12, {force: true});
+		cy.get('.color-map').should('have.css','color','rgb(46, 37, 0)');
+
+		//Checking if the correct color is being displayed
+		cy.get('@dialog').then(dialog => {
+		let value = dialog.get_value('color');
+		expect(value).to.equal('#2e2500')
+		});
+
+		//Clearing the field and checking if the field contains the placeholder "Choose a color"
+		cy.get_field('color','Color').click({force: true});
+		cy.get_field('color','Color').type('{selectall}').clear();
+		cy.get_field('color','Color').invoke('attr', 'placeholder').should('contain', 'Choose a color');
+
+	});
+});


### PR DESCRIPTION
Automation script for control type "Color". Below is the testing done by the script:

1. Creating a field with fieldtype "Color" in a modal dialog box.
2. Checking if the color palette is getting displayed after clicking on the color field.
3. Checking if the selected color is getting displayed in the color field.
4. Checking if the color can be selected from the displayed color palette and if the correct CSS is getting applied for the color.
5. Checking if the color can be selected from the displayed hue map and if the correct CSS is getting applied for the color.
6. Checking if the placeholder is getting displayed after the color field is cleared.