### PR TITLE
feat: declarative document comparison

### DIFF
--- a/cypress/integration/test_barcode_scanning.js
+++ b/cypress/integration/test_barcode_scanning.js
@@ -7,21 +7,7 @@ const input_scan = (scan_string) => {
 
 // assert partially supplied item attributes with actual frm object.
 const assert_items = (item_list) => {
-	cy.window()
-		.its("cur_frm")
-		.then((frm) => {
-			item_list.forEach((expected_item, idx) => {
-				const actual_item = frm.doc.items[idx];
-				for (const prop in expected_item) {
-					assert.equal(
-						expected_item[prop],
-						actual_item[prop],
-						`Expected :${JSON.stringify(expected_item, null, 2)}
-						 Actual: ${JSON.stringify(actual_item, null, 2)}`
-					);
-				}
-			});
-		});
+	cy.compare_document({items: item_list});
 };
 
 context("Barcode scanning", () => {

--- a/cypress/integration/test_item.js
+++ b/cypress/integration/test_item.js
@@ -14,14 +14,16 @@ context("Item", () => {
 
 		cy.get(".page-title").should("contain", "ITM-0018");
 		cy.get(".page-title").should("contain", "Enabled");
-		cy.get_field("item_name", "Data").should("have.value", "ITM-0018");
-		cy.get_field("item_group", "Link").should(
-			"have.value",
-			"All Item Groups"
-		);
-		cy.get_field("is_stock_item", "checkbox").should("be.checked");
-		cy.get_field("valuation_rate", "Data").should("have.value", "8,000.00");
-		cy.get_field("stock_uom", "Link").should("have.value", "Nos");
+
+		cy.compare_document({
+			item_name: "ITM-0018",
+			valuation_rate: "8000",
+			item_group: "All Item Groups",
+			stock_uom: "Nos",
+			is_stock_item: 1,
+			uoms: [{ uom: "Nos", conversion_factor: 1 }],
+		});
+
 		cy.remove_doc("Item", "ITM-0018");
 	});
 });

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,10 +26,35 @@
 
 const slug = (name) => name.toLowerCase().replaceAll(" ", "-");
 
+const compare_document = (expected, actual) => {
+	for (const prop in expected) {
+		if (expected[prop] instanceof Array) {
+			// recursively compare child documents.
+			expected[prop].forEach((item, idx) => {
+				compare_document(item, actual[prop][idx]);
+			});
+		} else {
+			assert.equal(
+				expected[prop],
+				actual[prop],
+				`${prop} should be equal.`
+			);
+		}
+	}
+};
+
 Cypress.Commands.add("go_to_doc", (doctype, name) => {
 	cy.visit(`/app/${slug(doctype)}/${encodeURIComponent(name)}`);
 });
 
 Cypress.Commands.add("new_doc_view", (doctype) => {
 	cy.visit(`/app/${slug(doctype)}/new`);
+});
+
+Cypress.Commands.add("compare_document", (expected_document) => {
+	cy.window()
+		.its("cur_frm")
+		.then((frm) => {
+			compare_document(expected_document, frm.doc);
+		});
 });


### PR DESCRIPTION
Instead of comparing one field at a time, this way we can just pass entire expected document for deep comparison. Very useful when writing tests that need many assertions. 

Before:

```javascript
cy.get_field("item_name", "Data").should("have.value", "ITM-0018");
cy.get_field("item_group", "Link").should("have.value", "All Item Groups");
cy.get_field("is_stock_item", "checkbox").should("be.checked");
cy.get_field("valuation_rate", "Data").should("have.value", "8,000.00");
cy.get_field("stock_uom", "Link").should("have.value", "Nos");
```

After:
```javascript
cy.compare_document({
	item_name: "ITM-0018",
	valuation_rate: "8000",
	item_group: "All Item Groups",
	stock_uom: "Nos",
	is_stock_item: 1,
	uoms: [{ uom: "Nos", conversion_factor: 1 }],
});
```

This is enormously faster to write and to cover more fields in assertions. You can basically do "Copy to clipboard" the final doc, remove fields that you don't want to check and paste it in code. Voila. 

--- 
Assumptions/drawbacks that are ignored for simpler code:

1. frm.doc object is what gets sent to the server for saving/updating. So even if it's not refreshed it's still correct. 
2. It's the Framework's job to make sure `frm.doc` object is rendered correctly (like currency symbol etc) 


Equivalent declarative doc creation PR is WIP but that's gonna take some time. 

Part of https://github.com/erpnext/erpnext_ui_tests/issues/15

cc: @nidhipurohit11 @yadavyk @Komal-Saraf0609 @netchampfaris 