### PR TITLE
fix(ui): accounts settings: unlink payment on invoice cancellation check, refactored PO

### DIFF
--- a/cypress/integration/TF_03_masters/TS_03_supplier.js
+++ b/cypress/integration/TF_03_masters/TS_03_supplier.js
@@ -11,9 +11,48 @@ context('Supplier', () => {
 
 		cy.get_field('supplier_name', 'Link').should('have.value', 'Medlife International Suppliers');
 		cy.get_field('supplier_group', 'Link').should('have.value', 'All Supplier Groups');
-        cy.location("pathname").should("not.be","/app/supplier/new");
+		cy.location("pathname").should("not.be","/app/supplier/new");
 
 		cy.get_page_title().should('contain', 'Medlife International Suppliers');
-        cy.get_page_title().should('contain', 'Enabled');
+		cy.get_page_title().should('contain', 'Enabled');
+	});
+
+	it('Adding supplier with address', () => {
+		cy.insert_doc(
+			"Supplier",
+				{
+					supplier_name: "Lisa Davis",
+					supplier_group: "All Supplier Groups",
+					default_currency: "INR",
+					default_price_list: "Standard Buying",
+				},
+			true
+		)
+
+		cy.insert_doc(
+			"Address",
+			{
+				address_title: "Lisa's Address",
+				address_type: "Billing",
+				address_line1: "38,1 Flr Welfare Chmbs, ",
+				address_line2: "Sec 17, Krishi Bazaar, Goregaon(e), ",
+				city: "Mumbai ",
+				country: "India",
+				is_primary_address: 1,
+				is_shipping_address: 1,
+				links: [
+					{
+						link_doctype: "Supplier",
+						link_name: "Lisa Davis",
+						link_title: "Lisa Davis",
+						parent: "Lisa's Address-Billing",
+						parentfield: "links",
+						parenttype: "Address",
+						doctype: "Dynamic Link"
+					}
+				]
+			},
+			true
+		)
 	});
 });

--- a/cypress/integration/TF_04_accounts/TS_04_accounts_settings
+++ b/cypress/integration/TF_04_accounts/TS_04_accounts_settings
@@ -4,11 +4,12 @@ context('Accounts Settings', () => {
 	});
 
 	it('Check unlinking of Payment on cancellation of Invoice', () => {
+		var today = new Date();
+		var date = today.getFullYear()+'-'+(today.getMonth()+1)+'-'+today.getDate();
+
 		cy.visit('/app/accounts-settings');
 		cy.get_input('unlink_payment_on_cancellation_of_invoice', 'checkbox').should('be.checked');
 
-		var today = new Date();
-		var date = today.getFullYear()+'-'+(today.getMonth()+1)+'-'+today.getDate();
 		cy.insert_doc(
 			"Sales Invoice",
 			{

--- a/cypress/integration/TF_04_accounts/TS_04_accounts_settings
+++ b/cypress/integration/TF_04_accounts/TS_04_accounts_settings
@@ -15,9 +15,9 @@ context('Accounts Settings', () => {
 			{
 					naming_series: "SINV-.YY.-",
 					posting_date: date,
-					customer: "Ankur Agarawal",
+					customer: "William Harris",
 					due_date: date,
-					items: [{"item_code": "Sleepy Owl Coffee Mug", "qty": 1, "rate": 400, "amount": 400}]
+					items: [{"item_code": "Apple iPhone 13 Pro Max", "qty": 1, "rate": 110000, "amount": 110000}]
 			},
 			true
 		).then((a)=>{

--- a/cypress/integration/TF_04_accounts/TS_04_accounts_settings
+++ b/cypress/integration/TF_04_accounts/TS_04_accounts_settings
@@ -1,0 +1,44 @@
+context('Accounts Settings', () => {
+	before(() => {
+		cy.login();
+	});
+
+	it('Check unlinking of Payment on cancellation of Invoice', () => {
+		cy.visit('/app/accounts-settings');
+		cy.get_input('unlink_payment_on_cancellation_of_invoice', 'checkbox').should('be.checked');
+
+		var today = new Date();
+		var date = today.getFullYear()+'-'+(today.getMonth()+1)+'-'+today.getDate();
+		cy.insert_doc(
+			"Sales Invoice",
+			{
+					naming_series: "SINV-.YY.-",
+					posting_date: date,
+					customer: "Ankur Agarawal",
+					due_date: date,
+					items: [{"item_code": "Sleepy Owl Coffee Mug", "qty": 1, "rate": 400, "amount": 400}]
+			},
+			true
+		).then((a)=>{
+			console.log(a);
+			cy.visit('app/sales-invoice/'+ a.name);
+			cy.submit('Unpaid');
+			cy.click_dropdown_action('Create', 'Payment');
+			cy.set_input('reference_no', 'ABC-1234');
+			cy.set_today('reference_date');
+			cy.save();
+			cy.click_toolbar_button('Submit');
+			cy.click_modal_primary_button('Yes');
+
+			cy.visit('app/sales-invoice');
+			cy.click_listview_row_item(0);
+			cy.click_toolbar_button('Cancel');
+			cy.click_modal_primary_button('Yes');
+			cy.hide_dialog();
+			cy.wait(200);
+
+			cy.get_open_dialog().should('contain', 'Message');
+			cy.get('.msgprint').invoke('text').should('match', /Payment Entries ACC-PAY-.+ are un-linked/);
+		});
+	});
+});

--- a/cypress/integration/TF_06_buying/TS_01_purchase_order.js
+++ b/cypress/integration/TF_06_buying/TS_01_purchase_order.js
@@ -1,32 +1,7 @@
 context('Create Purchase Order', () => {
 	before(() => {
 		cy.login();
-		cy.visit('/app');
-
-		cy.insert_doc(
-			"Item",
-				{
-					item_code: "Fastrack Analog Black Dial Watch",
-					item_group: "All Item Groups",
-					valuation_rate: 15000,
-					stock_uom: "Nos",
-				},
-			true
-		)
-
-		cy.insert_doc(
-			"Supplier",
-				{
-					supplier_name: "Lisa Davis",
-					supplier_group: "All Supplier Groups",
-					default_currency: "INR",
-					default_price_list: "Standard Buying",
-				},
-			true
-		)
 	});
-
-
 
 	it('Create Purchase Order', () => {
 		var today = new Date();
@@ -50,18 +25,18 @@ context('Create Purchase Order', () => {
 		cy.get_input('currency').should('have.value', 'INR');
 		cy.get_input('buying_price_list').should('have.value', 'Standard Buying');
 
-		cy.set_link('items.item_code', 'Fastrack Analog Black Dial Watch');
+		cy.set_link('items.item_code', 'Apple iPhone 13 Pro Max');
 		cy.get_input('items.schedule_date').should('have.value', today);
 		cy.get_input('qty').should('have.value', "1.000");
 		cy.get_input('uom').should('have.value', "Nos");
-		cy.set_input('rate', '15000');
+		cy.set_input('rate', '110000');
 		cy.get_input('rate').blur();
-		cy.get_read_only('amount').should('contain', "15,000");
+		cy.get_read_only('amount').should('contain', "1,10,000");
 
 		cy.get_read_only('total_qty').should('contain', "1");
-		cy.get_read_only('total').should('contain', "₹ 15,000.00");
-		cy.get_read_only('grand_total').should('contain', "₹ 15,000.00");
-		cy.get_read_only('rounded_total').should('contain', "₹ 15,000.00");
+		cy.get_read_only('total').should('contain', "₹ 1,10,000.00");
+		cy.get_read_only('grand_total').should('contain', "₹ 1,10,000.00");
+		cy.get_read_only('rounded_total').should('contain', "₹ 1,10,000.00");
 
 		cy.click_toolbar_button('Save');
 		cy.get_page_title().should('contain', 'Draft');


### PR DESCRIPTION
This PR checks the accounts settings option "Unlink Payment on Cancellation of Invoice", it - 
- Creates a sales invoice and payment against it
- Cancel the invoice, and validate the alert message. 

This also includes refactoring of Purchase Order - 
- Added required masters like supplier
- Removed fixtures from purchase order script