### PR TITLE
test: Adding test script for "Notifications"

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,7 +3,7 @@
   "projectId": "da59y9",
   "adminPassword": "admin",
   "defaultCommandTimeout": 20000,
-  "pageLoadTimeout": 15000,
+  "pageLoadTimeout": 20000,
   "retries": {
     "runMode": 2,
     "openMode": 0

--- a/cypress/integration/TF_02_framework/TS_09_notifications.js
+++ b/cypress/integration/TF_02_framework/TS_09_notifications.js
@@ -8,10 +8,10 @@ context('Notifications', () => {
 		//Creating a new user with all the roles assigned
 		cy.create_records({
 			doctype: 'User',
-			email: 'billy_jones@example.com',
-			first_name: 'Billy Jones'
+			email: 'test_notif_user@example.com',
+			first_name: 'Test Notification User'
 		});
-		cy.list_open_row('Billy Jones');
+		cy.list_open_row('Test Notification User');
 		cy.wait(5000);
 		cy.get('.role-editor button.select-all').click({force: true});
 		cy.wait(500);
@@ -32,7 +32,7 @@ context('Notifications', () => {
 
 	it('Login in into the new user and verifying if the notifications panel is initially empty', () => {
 		//Login in into the new user
-		cy.user_login('billy_jones@example.com', 'password@12345');
+		cy.user_login('test_notif_user@example.com', 'password@12345');
 		cy.get('.navbar .nav-item .nav-link[data-original-title="Notifications"]').click({force: true});
 		cy.get('.notification-list-header').should('exist');
 
@@ -49,7 +49,7 @@ context('Notifications', () => {
 		cy.get('#todays_events').click({force: true});
 		cy.get('#todays_events:visible').should('have.class', 'active');
 		cy.get('.notification-list-body .panel-events').should('contain', 'No Upcoming Events');
-		cy.logout('Billy Jones');
+		cy.logout('Test Notification User');
 		cy.user_login('administrator', 'admin');
 		cy.wait(2000);
 	});
@@ -60,10 +60,10 @@ context('Notifications', () => {
 
 		//Assigning todo to the new user Billy Jones
 		cy.get('.form-sidebar button.add-assignment-btn').click({force: true});
-		cy.set_input('assign_to', 'billy_jones{enter}');
+		cy.set_input('assign_to', 'test_notif_user{enter}');
 		cy.click_modal_primary_button('Add');
 		cy.logout('Administrator');
-		cy.user_login('billy_jones@example.com', 'password@12345');
+		cy.user_login('test_notif_user@example.com', 'password@12345');
 		cy.get('.navbar .nav-item .nav-link[data-original-title="Notifications"]').click({force: true});
 
 		//Checking if the notification is sent and is visible in the notifications panel of the user Billy Jones
@@ -72,7 +72,7 @@ context('Notifications', () => {
 	});
 
 	it('Deleting user and todo', () => {
-		cy.logout('Billy Jones');
+		cy.logout('Test Notification User');
 		cy.user_login('administrator', 'admin');
 
 		//Deleting the user Billy Jones

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -291,3 +291,41 @@ Cypress.Commands.add('clear_filter', () => {
 Cypress.Commands.add('get_filter_button', () => {
 	cy.get('.filter-selector > .btn:visible');
 });
+
+Cypress.Commands.add('set_input_awesomebar', (text) => {
+	cy.get('#navbar-search').type(`${text}{enter}`, {delay: 1000});
+});
+
+Cypress.Commands.add('click_navbar_icon', (name) => {
+	cy.get(`.navbar .dropdown-navbar-user .avatar[title="${name}"]`).click({force: true});
+});
+
+Cypress.Commands.add('click_navbar_dropdown', (text) => {
+	cy.get('#toolbar-user').contains(text).click({force: true});
+});
+
+Cypress.Commands.add('user_login', (email, password) => {
+	cy.get('.navbar .nav-item .nav-link[href="/login"]').click({force: true});
+	cy.wait(5000);
+	cy.get('#login_email').type(`${email}`);
+	cy.get('#login_password').type(`${password}`);
+	cy.intercept('/api').as('api');
+	cy.get('.btn-login').contains('Login').click({force: true});
+	cy.wait('@api');
+});
+
+Cypress.Commands.add('logout', (user_name) => {
+	cy.click_navbar_icon(`${user_name}`);
+	cy.intercept('/api').as('api');
+	cy.click_navbar_dropdown('Log out');
+	cy.wait('@api');
+});
+
+Cypress.Commands.add('delete_first_record', (doctype_name) => {
+	cy.wait(1000);
+	cy.set_input_awesomebar(`${doctype_name}`);
+	cy.click_listview_checkbox(0);
+	cy.click_action_button('Actions');
+	cy.click_toolbar_dropdown('Delete');
+	cy.click_modal_primary_button('Yes', {multiple: true});
+});


### PR DESCRIPTION
The above script does testing for the following:

1. Creates a new user with all the roles assigned and also creates a todo.
2. Logs in into the new user and checks if the notification panel is initially in an empty state.
3. Checks if the notification panel consists of 2 tabs i.e Notification and Today's Event and checks if the initial tab i.e "Notification" is the active one.
4. Logs in into the "Admin" user and assigns a todo to the new user "Billy Jones".
5. Logs in into the user "Billy Jones" and checks if the assigned todo is visible in the notifications panel.
6. Logs in into the admin login again and deletes the user and the todo so as to bring the system in the previous state.