### PR TITLE
test: Adding test script for "Address" doctype

### DIFF
--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -109,7 +109,7 @@ jobs:
         run: cd ~/frappe-bench/ && bench --site test_site execute erpnext_ui_tests.test_utils.site_setup.execute
 
       - name: cypress pre-requisites
-        run: cd ~/frappe-bench/apps/frappe && yarn add cypress-file-upload@^5 @4tw/cypress-drag-drop@^2 @testing-library/cypress@^8 --no-lockfile
+        run: cd ~/frappe-bench/apps/frappe && yarn add cypress-file-upload@^5 @4tw/cypress-drag-drop@^2 cypress-real-events @testing-library/cypress@^8 --no-lockfile
 
       - name: Build Assets
         run: cd ~/frappe-bench/ && bench build

--- a/.github/workflows/ui-tests.yml
+++ b/.github/workflows/ui-tests.yml
@@ -5,6 +5,10 @@ on:
     paths-ignore:
       - "**.md"
   workflow_dispatch:
+  push:
+    branches: [ develop ]
+    paths-ignore:
+      - '**.md'
   schedule:
     # Run everday at midnight UTC / 5:30 IST
     - cron: "0 0 * * *"

--- a/cypress.json
+++ b/cypress.json
@@ -15,6 +15,7 @@
     "TF_04_accounts/*",
     "TF_05_selling/*",
     "TF_06_buying/*",
-    "TF_07_stock/*"
+    "TF_07_stock/*",
+    "TF_08_manufacturing/*"
   ]
 }

--- a/cypress.json
+++ b/cypress.json
@@ -3,7 +3,7 @@
   "projectId": "da59y9",
   "adminPassword": "admin",
   "defaultCommandTimeout": 20000,
-  "pageLoadTimeout": 20000,
+  "pageLoadTimeout": 30000,
   "retries": {
     "runMode": 2,
     "openMode": 0

--- a/cypress/integration/TF_02_framework/TS_06_inbox_view.js
+++ b/cypress/integration/TF_02_framework/TS_06_inbox_view.js
@@ -7,7 +7,8 @@ context('Inbox View', () => {
 	it('Setting Email and enabling default email account', () => {
 		//Setting Email account for user administrator
 		cy.list_open_row('Administrator');
-		cy.click_section('Email');
+		cy.wait(500);
+		cy.open_section('Email');
 		cy.grid_add_row('user_emails');
 		cy.set_link('user_emails.email_account','Notifications');
 		cy.save();
@@ -26,13 +27,14 @@ context('Inbox View', () => {
 		//Verifying if the Inbox view has been enabled
 		cy.go_to_list('Communication');
 		cy.location('pathname').should('eq', '/app/communication');
+		cy.reload();
 		cy.get_page_title().should('contain', 'Communication');
 		cy.click_custom_toolbar_button('List View');
 		cy.click_toolbar_dropdown('Inbox');
 		cy.location('pathname').should('eq', '/app/communication/view/inbox/Notifications');
 		cy.get_page_title().should('contain', 'Notifications');
-		cy.get('.views-section:visible').should('contain', 'Inbox');	
-		cy.get('.views-section .selected-view:visible').should('contain', 'Notifications');	
+		cy.get('.views-section:visible').should('contain', 'Inbox');
+		cy.get('.views-section .selected-view:visible').should('contain', 'Notifications');
 		cy.get('.views-section .selected-view:visible').click({force: true});
 		cy.get('.views-section .list-link:visible').find('li').should('have.length', 3);
 
@@ -58,7 +60,7 @@ context('Inbox View', () => {
 			.and('contain', 'admin@example.com');
 	});
 
-	it('Deleting the mail and reseting the email account configurations', () => {	
+	it('Deleting the mail and reseting the email account configurations', () => {
 		cy.click_custom_toolbar_button('Inbox View');
 		cy.click_toolbar_dropdown('List');
 		cy.intercept('/api').as('api');

--- a/cypress/integration/TF_02_framework/TS_09_notifications.js
+++ b/cypress/integration/TF_02_framework/TS_09_notifications.js
@@ -9,11 +9,11 @@ context('Notifications', () => {
         cy.new_doc('User');
         cy.set_input('email', 'test_notif_user@example.com');
         cy.set_input('first_name', 'Test Notification User');
+        cy.get_field('send_welcome_email', 'Check').uncheck();
         cy.save();
-		cy.hide_dialog();
         cy.set_input_awesomebar('User');
         cy.list_open_row('Test Notification User');
-        cy.wait(5000);
+        cy.wait(1000);
         cy.get('.role-editor button.select-all').click({force: true});
         cy.wait(500);
         cy.click_section('Change Password');
@@ -28,11 +28,11 @@ context('Notifications', () => {
             priority: 'Low',
             description: 'This is a test notifications Todo'
         });
-        cy.logout('Administrator');
     });
 
     it('Login in into the new user and verifying if the notifications panel is initially empty', () => {
         //Login in into the new user
+        cy.logout('Administrator');
         cy.user_login('test_notif_user@example.com', 'password@12345');
         cy.get('.navbar .nav-item .nav-link[data-original-title="Notifications"]').click({force: true});
         cy.get('.notification-list-header').should('exist');

--- a/cypress/integration/TF_02_framework/TS_11_address.js
+++ b/cypress/integration/TF_02_framework/TS_11_address.js
@@ -94,7 +94,9 @@ context('Address', () => {
 		cy.wait(3000);
 		cy.get('.title-text:visible').click({force: true, scrollBehaviour: false});
 		cy.set_input('name', 'Test Billing');
+		cy.intercept('/api').as('api');
 		cy.click_modal_primary_button('Rename');
+		cy.wait('@api');
 		cy.wait(8000);
 		cy.get('.title-text:visible').should('contain', 'Test Billing');
 	});

--- a/cypress/integration/TF_02_framework/TS_11_address.js
+++ b/cypress/integration/TF_02_framework/TS_11_address.js
@@ -1,0 +1,111 @@
+context('Address', () => {
+    before(() => {
+        cy.login();
+        cy.go_to_list('Website');
+    });
+
+    it('Creating Billing and Shipping address', () => {
+		cy.go_to_list('Address');
+		cy.location('pathname').should('eq', '/app/address');
+		cy.click_listview_primary_button('Add Address');
+
+		//Creating Billing address
+		cy.set_input('address_title', 'Test Address Billing');
+
+		//Checking the options available in the address type field
+		cy.get_select('address_type').should('contain', 'Billing')
+			.and('contain', 'Shipping')
+			.and('contain', 'Office')
+			.and('contain', 'Personal')
+			.and('contain', 'Plant')
+			.and('contain', 'Postal')
+			.and('contain', 'Shop')
+			.and('contain', 'Subsidiary')
+			.and('contain', 'Warehouse')
+			.and('contain', 'Current')
+			.and('contain', 'Permanent')
+			.and('contain', 'Other');
+		cy.click_toolbar_button('Save');
+		cy.get_open_dialog().should('contain', 'Missing Fields')
+			.and('contain', 'Mandatory fields required in Address');
+		cy.hide_dialog();
+		cy.set_input('address_line1', 'Frappe Technologies Pvt. Ltd, Vidhyavihar');
+		cy.set_input('city', 'Mumbai');
+		cy.set_link('country', 'India');
+		cy.set_input('email_id', 'test');
+		cy.click_toolbar_button('Save');
+		cy.get_open_dialog().should('contain', 'Message')
+			.and('contain', 'test is not a valid Email Address');
+		cy.hide_dialog();
+		cy.set_input('email_id', 'test@example.com');
+		cy.get_field('is_primary_address', 'Check').check();
+		cy.save();
+		cy.get_page_title().should('contain', 'Test Address Billing-Billing');
+		cy.get('.indicator-pill').should('contain', 'Enabled');
+
+		//Creating Shipping address and enabling "Preffered Shipping address"
+		cy.go_to_list('Address');
+		cy.click_listview_primary_button('Add Address');
+		cy.set_input('address_title', 'Test Address Shipping');
+		cy.set_select('address_type', 'Shipping');
+		cy.set_input('address_line1', 'Frappe Technologies Pvt. Ltd, Vidhyavihar');
+		cy.set_input('city', 'Mumbai');
+		cy.set_link('country', 'India');
+		cy.get_field('is_shipping_address', 'Check').check();
+		cy.save();
+		cy.get_page_title().should('contain', 'Test Address Shipping-Shipping');
+		cy.get('.indicator-pill').should('contain', 'Enabled');
+    });
+	it('Creating a customer and checking if the billing and shipping address is fetched', () => {
+		//Creating customer
+		cy.new_doc('Customer');
+		cy.set_input('customer_name', 'Test Customer Address');
+		cy.set_link('customer_group', 'Commercial');
+		cy.set_link('territory', 'All Territories');
+		cy.save();
+
+		//Adding customer reference in the billing address
+		cy.set_input_awesomebar('address');
+		cy.list_open_row('Test Address Billing-Billing');
+		cy.grid_add_row('links');
+		cy.set_link('links.link_doctype', 'Customer');
+		cy.set_link('links.link_name', 'Test Customer Address');
+		cy.save();
+
+		//Adding customer reference in the shipping address
+		cy.set_input_awesomebar('address');
+		cy.list_open_row('Test Address Shipping-Shipping');
+		cy.grid_add_row('links');
+		cy.set_link('links.link_doctype', 'Customer');
+		cy.set_link('links.link_name', 'Test Customer Address');
+		cy.save();
+
+		//Going into the sales order doc and checking if the billing and shipping address are automatically fetched
+		cy.new_doc('Sales Order');
+		cy.set_link('customer', 'Test Customer Address');
+		cy.click_section('Address and Contact');
+		cy.get_field('customer_address', 'Link').should('have.value', 'Test Address Billing-Billing');
+		cy.get_field('shipping_address_name', 'Link').should('have.value', 'Test Address Shipping-Shipping');
+	});
+
+	it('Renaming the address title', () => {
+		cy.go_to_list('address');
+		cy.list_open_row('Test Address Billing-Billing');
+		cy.wait(3000);
+		cy.get('.title-text:visible').click({force: true, scrollBehaviour: false});
+		cy.set_input('name', 'Test Billing');
+		cy.click_modal_primary_button('Rename');
+		cy.wait(8000);
+		cy.get('.title-text:visible').should('contain', 'Test Billing');
+	});
+
+	it('Deleting the addresses and customer', () => {
+		cy.wait(2000);
+		cy.delete_first_record('address');
+		cy.hide_dialog();
+		cy.delete_first_record('address');
+		cy.hide_dialog();
+		cy.delete_first_record('customer');
+		cy.hide_dialog();
+	});
+});

--- a/cypress/integration/TF_04_accounts/TS_06_currency_exchange_rate.js
+++ b/cypress/integration/TF_04_accounts/TS_06_currency_exchange_rate.js
@@ -1,0 +1,78 @@
+const TEST_RATE = 110000;
+
+context('Currency and Exchange Rate Check', () => {
+	before(() => {
+		cy.login();
+		cy.visit('/app');
+	});
+
+	it('Create quotation with different currency and fetching currency exchange rate', () => {
+		var today = new Date();
+		var date = today.getFullYear()+'-'+(today.getMonth()+1)+'-'+today.getDate();
+
+		cy.insert_doc(
+			"Quotation",
+				{
+					naming_series: 'SAL-QTN-.YYYY.-',
+					quotation_to: 'Customer',
+					party_name: 'William Harris',
+					transaction_date: date,
+					order_type: 'Sales',
+					currency: 'INR',
+					items: [{item_code: 'Apple iPhone 13 Pro Max', qty: 1, rate: TEST_RATE}]
+				},
+			true
+		).then((c)=>{
+			console.log(c);
+			cy.visit('app/quotation/'+ c.name);
+			cy.get_input('quotation_to').should('have.value', 'Customer');
+			cy.get_input('party_name').should('have.value', 'William Harris');
+			cy.wait(200);
+
+			cy.click_section('Currency and Price List');
+			cy.set_link('currency', 'EUR');
+			cy.wait(400);
+
+			cy.click_section('Currency and Price List');
+			cy.get_input('conversion_rate')
+ 				.invoke('val')
+				.then(val => {
+					const exRate = val;
+					cy.log(exRate);
+					const roundedExchRate = Number(exRate).toFixed(2);
+
+					const rate = (110000/exRate);
+					const roundedRate = Number(rate).toFixed(2);
+					const formattedRate = new Intl.NumberFormat().format(roundedRate);
+					cy.log("formatted rate " + formattedRate);
+					const rateInCurrency = ('€ '+formattedRate);
+
+					cy.get_input('items.item_code').should('have.value', 'Apple iPhone 13 Pro Max');
+					cy.get_input('qty').should('have.value', "1.000");
+					cy.get_input('rate').should('have.value', formattedRate);
+					cy.get_input('amount').should('have.value', formattedRate);
+
+					const total = (roundedRate * roundedExchRate);
+					const roundedTotal = Number(total).toFixed(2);
+					const formattedTotal = Intl.NumberFormat('en-IN').format(roundedTotal);
+					cy.log("total " + formattedTotal);
+					const totalInCurrency = ('₹ '+formattedTotal);
+
+					cy.get_read_only('total_qty').should('contain', "1");
+					cy.get_read_only('total').should('contain', rateInCurrency);
+					cy.get_read_only('base_total').should('contain', totalInCurrency);
+
+					cy.get_read_only('base_grand_total').should('contain', totalInCurrency);
+					cy.get_read_only('grand_total').should('contain', rateInCurrency);
+					cy.get_read_only('base_rounded_total').should('contain', totalInCurrency);
+					cy.get_read_only('rounded_total').should('contain', rateInCurrency);
+				});
+
+			cy.click_toolbar_button('Save');
+			cy.get_page_title().should('contain', 'Draft');
+			cy.click_toolbar_button('Submit');
+			cy.click_modal_primary_button('Yes');
+			cy.get_page_title().should('contain', 'Open');
+		});
+	});
+});

--- a/cypress/integration/TF_05_selling/TS_02_quotation.js
+++ b/cypress/integration/TF_05_selling/TS_02_quotation.js
@@ -32,7 +32,7 @@ context('Quotation Creation', () => {
 		cy.get_read_only('shipping_address_name').should('contain', "William's Address-Billing");
 		cy.get_read_only('territory').should('contain', 'All Territories');
 
-		cy.click_section('Currency and Price List');
+		cy.open_section('Currency and Price List');
 		cy.get_input('currency').should('have.value', 'INR');
 		cy.get_input('selling_price_list').should('have.value', 'Standard Selling');
 

--- a/cypress/integration/TF_05_selling/TS_06_delivery_note.js
+++ b/cypress/integration/TF_05_selling/TS_06_delivery_note.js
@@ -40,6 +40,9 @@ context('Delivery Note Creation', () => {
 		cy.get_page_title().should('contain', 'Draft');
 		cy.click_toolbar_button('Submit');
 		cy.click_modal_primary_button('Yes');
+		//cy.hide_dialog();
+
+		cy.reload();
 		cy.get_page_title().should('contain', 'Completed');
 		cy.get_page_title().should('contain', 'William Harris');
 

--- a/cypress/integration/TF_05_selling/TS_07_delivery_sales_return.js
+++ b/cypress/integration/TF_05_selling/TS_07_delivery_sales_return.js
@@ -71,6 +71,7 @@ context('Delivery Return Check', () => {
 		cy.get_page_title().should('contain', 'Draft');
 		cy.click_toolbar_button('Submit');
 		cy.click_modal_primary_button('Yes');
+		cy.reload();
 		cy.get_page_title().should('contain', 'Return');
 
 		cy.click_dropdown_action('View', 'Stock Ledger');

--- a/cypress/integration/TF_07_stock/TS_11_stock_entry_serialized.js
+++ b/cypress/integration/TF_07_stock/TS_11_stock_entry_serialized.js
@@ -26,8 +26,11 @@ context('Create Stock Entry', () => {
 		cy.location("pathname").should("eq","/app/stock-entry/new-stock-entry-1");
 		cy.set_link('stock_entry_type', 'Material Receipt');
 		cy.set_link('to_warehouse', 'Stores - WP');
-		cy.set_link('items.item_code', 'Solid Wood Armchair In Honey Oak Finish');
-		cy.set_input('items.qty', 5);
+		cy.grid_open_row('items', 1);
+		cy.set_link('item_code', 'Solid Wood Armchair In Honey Oak Finish');
+		cy.get_field('qty').clear();
+		cy.set_input('qty', 5);
+		cy.close_grid_edit_modal();
 		cy.save();
 		cy.wait(500);
 		cy.submit('Submitted');

--- a/cypress/integration/TF_07_stock/TS_16_execute_job_cards.js
+++ b/cypress/integration/TF_07_stock/TS_16_execute_job_cards.js
@@ -12,7 +12,6 @@ context('Executing Job Cards', () => {
 
 	it('Start operation via Job Card', () => {
 		cy.visit('app/job-card/view/list');
-		cy.clear_filter();
 		cy.click_listview_row_item(0);
 		cy.click_toolbar_button('Start Job');
 		cy.on('window:alert',  (str) =>  {
@@ -28,7 +27,6 @@ context('Executing Job Cards', () => {
 		cy.visit('app/job-card/view/list');
 
 		//Complete first operation
-		cy.clear_filter();
 		cy.click_listview_row_item(0);
 		cy.click_toolbar_button('Complete Job');
 		cy.set_input('qty', '1');

--- a/cypress/integration/TF_07_stock/TS_17_finish_work_order.js
+++ b/cypress/integration/TF_07_stock/TS_17_finish_work_order.js
@@ -1,4 +1,4 @@
-context('Executing Job Cards', () => {
+context('Finish work order', () => {
 	before(() => {
         cy.login();
     });

--- a/cypress/integration/TF_07_stock/TS_18_quality_inspection_template.js
+++ b/cypress/integration/TF_07_stock/TS_18_quality_inspection_template.js
@@ -1,0 +1,56 @@
+context('Quality Inspection Template', () => {
+	before(() => {
+        cy.login();
+    });
+
+	it('Create Inspection Parameters', () => {
+        cy.new_doc('Quality Inspection Parameter');
+        cy.set_input('parameter', 'Weight check');
+        cy.save();
+		cy.wait(500);
+		cy.new_doc('Quality Inspection Parameter');
+        cy.set_input('parameter', 'Loading test with 80 kg force');
+        cy.save();
+		cy.new_doc('Quality Inspection Parameter');
+        cy.set_input('parameter', 'Bending strength');
+        cy.save();
+		cy.new_doc('Quality Inspection Parameter');
+        cy.set_input('parameter', 'Compressive strength');
+        cy.save();
+    });
+
+    it('Create Quality Inspection Template', () => {
+        cy.new_doc('Quality Inspection Template');
+        cy.set_input('quality_inspection_template_name', 'Quality Inspection Template - I');
+
+		cy.grid_open_row('item_quality_inspection_parameter', 1);
+		cy.set_link('specification', 'Weight check');
+		cy.get_field('numeric', 'checkbox').check();
+		cy.set_input('min_value', '220');
+		cy.set_input('max_value', '440');
+		cy.close_grid_edit_modal();
+
+		cy.grid_add_row('item_quality_inspection_parameter');
+		cy.grid_open_row('item_quality_inspection_parameter', 2);
+		cy.set_link('specification', 'Loading test with 80 kg force');
+		cy.set_input('min_value', '300');
+		cy.set_input('max_value', '440');
+		cy.close_grid_edit_modal();
+
+		cy.grid_add_row('item_quality_inspection_parameter');
+		cy.grid_open_row('item_quality_inspection_parameter', 3);
+		cy.set_link('specification', 'Bending strength');
+		cy.set_input('min_value', '15000');
+		cy.set_input('max_value', '17000');
+		cy.close_grid_edit_modal();
+
+		cy.grid_add_row('item_quality_inspection_parameter');
+		cy.grid_open_row('item_quality_inspection_parameter', 4);
+		cy.set_link('specification', 'Compressive strength');
+		cy.set_input('min_value', '1000');
+		cy.set_input('max_value', '8000');
+		cy.close_grid_edit_modal();
+
+		cy.save();
+    });
+});

--- a/cypress/integration/TF_08_manufacturing/TS_01_production_plan.js
+++ b/cypress/integration/TF_08_manufacturing/TS_01_production_plan.js
@@ -1,0 +1,46 @@
+context('Production Plan', () => {
+	before(() => {
+        cy.login();
+    });
+
+	it('Create a Sales Order', () => {
+		cy.new_doc("Sales Order");
+		cy.set_link('customer', 'William Harris');
+		cy.set_select('order_type', 'Sales');
+		cy.set_today('delivery_date');
+		cy.set_link('items.item_code', 'Classic Dining Table-ACACIA');
+		cy.set_input('items.qty', '1');
+		cy.grid_open_row('items', 1);
+		cy.save();
+		cy.wait(500);
+		cy.submit('To Deliver and Bill');
+		});
+
+	it('Create Production Plan', () => {
+		cy.new_doc("Production Plan");
+		cy.set_select('get_items_from', 'Sales Order');
+
+		//Set filters to find Sales Order
+		cy.set_link('item_code', 'Classic Dining Table-ACACIA');
+		cy.set_select('sales_order_status', 'To Deliver and Bill');
+		cy.findByRole('button', {name: 'Get Sales Orders'}).click();
+		cy.findByRole('button', {name: 'Get Finished Goods for Manufacture'}).click();
+
+		//Setting items
+		cy.grid_open_row('po_items', 1);
+		cy.get_input('planned_qty', '1');
+		cy.get_read_only('pending_qty').should('contain', '1');
+		cy.close_grid_edit_modal();
+
+		//Setting material requirements planning
+		cy.get_field('ignore_existing_ordered_qty', 'checkbox').check();
+		cy.get_field('ignore_existing_ordered_qty', 'checkbox').should('be.checked');
+		cy.set_link('for_warehouse', 'Work in Progress - WP');
+		cy.findByRole('button', {name: 'Get Raw Materials For Production'}).click();
+		cy.save();
+		cy.wait(500);
+		cy.submit('Not Started');
+		cy.get_page_title().should('contain', 'Not Started');
+	});
+});
+

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -118,7 +118,7 @@ Cypress.Commands.add('set_input_multiselect', (fieldname, value) => {
 Cypress.Commands.add("_set_input", (fieldname, value) => {
 	cy.get_input(fieldname)
 		.clear({scrollBehavior: 'center'})
-		.type(value, {delay: 20, scrollBehavior: false})
+		.type(value, {delay: 100, scrollBehavior: false})
 });
 
 Cypress.Commands.add("set_input", (fieldname, value) => {
@@ -220,6 +220,13 @@ Cypress.Commands.add('click_section', (title) => {
 	return cy.get('.section-head:visible').contains(title).click({scrollBehavior: false, force: true});
 });
 
+Cypress.Commands.add('open_section', (title) => {
+	if (open && !Cypress.$(`.section-head:visible:contains(${title})`).hasClass('collapsed')) {
+		return cy.get('.section-head:visible').contains(title);
+	}
+	return cy.click_section(title);
+});
+
 Cypress.Commands.add('grid_add_row', (fieldname) => {
 	cy.get(`[data-fieldname="${fieldname}"] .grid-add-row:visible`).click({scrollBehavior: 'center'});
 });
@@ -279,7 +286,7 @@ Cypress.Commands.add('clear_filter', () => {
 		url: 'api/method/frappe.model.utils.user_settings.save'
 	}).as('filter-saved');
 	cy.get('.filter-section .filter-button:visible').click({force: true});
-	cy.wait(300);
+	cy.wait("@filter-saved");
 	cy.get('.filter-popover').should('exist');
 	cy.get('.filter-popover').then(popover => {
 		if (popover.find('input.input-with-feedback')[0].value != '') {
@@ -318,7 +325,6 @@ Cypress.Commands.add('click_navbar_dropdown', (text) => {
 
 Cypress.Commands.add('user_login', (email, password) => {
 	cy.get('.navbar .nav-item .nav-link[href="/login"]').click({force: true});
-	cy.wait(5000);
 	cy.get('#login_email').type(`${email}`);
 	cy.get('#login_password').type(`${password}`);
 	cy.intercept('/api').as('api');


### PR DESCRIPTION
The above script does testing for the following:

1. Creates address for both shipping and billing.
2. Checking if the required types are available in the address types dropdown.
3. Enabling "Preferred Billing address" and "Preferred Shipping address".
4. Creates a customer and adds customer link reference in the shipping and billing address.
5. Visiting the sales order doctype and checking if the shipping and billing address is automatically fetched as soon as the customer is selected.
6. Renames the billing address and checks if the document gets renamed.
7. Deletes the address and customer created.