### PR TITLE
test: Adding test script for "Report Builder"

### DIFF
--- a/cypress/integration/TF_02_framework/TS_10_role_profile.js
+++ b/cypress/integration/TF_02_framework/TS_10_role_profile.js
@@ -76,16 +76,16 @@ context('Role Profile', () => {
 		cy.get('.role-editor [type="checkbox"][data-unit="Sales Manager"]:visible').should('be.checked');
 
 		//Deleting the user and the role profile
-		cy.remove_doc('User', 'test_rle_user@example.com');
-		cy.remove_doc('Role Profile', 'Test RoleProfile1');
+		cy.delete_doc('User', 'test_rle_user@example.com');
+		cy.delete_doc('Role Profile', 'Test RoleProfile1');
 	});
 
 	after(() => {
         //Deleting the user
-		cy.remove_doc('User', 'test_role_user123@exapmle.com');
-		cy.remove_doc('User', 'test_role_user@exapmle.com');
+		cy.delete_doc('User', 'test_role_user123@exapmle.com');
+		cy.delete_doc('User', 'test_role_user@exapmle.com');
 
 		//Deleting the role profile
-		cy.remove_doc('Role Profile', 'Test RoleProfile');
+		cy.delete_doc('Role Profile', 'Test RoleProfile');
     });
 });

--- a/cypress/integration/TF_02_framework/TS_13_report_builder.js
+++ b/cypress/integration/TF_02_framework/TS_13_report_builder.js
@@ -1,0 +1,77 @@
+context("Report Builder", () => {
+	before(() => {
+		cy.login();
+		cy.visit("/app");
+
+		cy.call(
+			"erpnext_ui_tests.test_utils.todo.create_todo_test_docs"
+		);
+	});
+
+	it('Creates a report with type report builder and checks "Pick Column" functionality', () => {
+		//Creating a new report named "Test Report Builder" with type "Report Builder"
+		cy.new_doc('Report');
+		cy.set_input('report_name', 'Test Report Builder');
+		cy.set_select('report_type', 'Report Builder');
+		cy.set_link('ref_doctype', 'ToDo');
+		cy.save();
+		cy.get_field('module', 'Link').should('have.value', 'Desk');
+
+		//Checks if creating a new report with the same name throws error
+		cy.new_doc('Report');
+		cy.set_input('report_name', 'Test Report Builder');
+		cy.get('.help-box').should('contain', 'Test Report Builder already exists. Select another name');
+		cy.set_link('ref_doctype', 'todo');
+		cy.set_select('report_type', 'Report Builder');
+		cy.save();
+		cy.get_open_dialog().should('contain', 'Duplicate Name')
+		.and('contain', 'Report Test Report Builder already exists');
+		cy.get('.modal').type('{esc}');
+
+		//Visiting the created report "Test Report Builder" and checks if the table is created
+		cy.go_to_list('Report');
+		cy.list_open_row('Test Report Builder');
+		cy.click_toolbar_button('Show Report');
+		cy.location('pathname').should('eq', '/app/todo/view/report/Test%20Report%20Builder');
+		cy.get_page_title().should('contain', 'Test Report Builder');
+		cy.get('.datatable').should('exist');
+		cy.get('.datatable .dt-header .dt-cell--header').should('contain', 'ID')
+		.and('contain', 'Description')
+		.and('contain', 'Status')
+		.and('contain', 'Priority')
+		.and('contain', 'Due Date')
+		.and('contain', 'Allocated To')
+		.and('contain', 'Reference Type')
+		.and('contain', 'Reference Name');
+
+		//Checks "Pick Columns" functionality and checks if the choosed column gets added to the existing table structure
+		cy.click_menu_button();
+		cy.click_toolbar_dropdown('Pick%20Columns');
+		cy.get('.modal-content .checkbox-options input[data-unit="assigned_by"]:visible')
+			.click({force: true});
+		cy.click_modal_primary_button('Submit');
+		cy.get('.datatable .dt-header .dt-cell--header').should('contain', 'Assigned By');
+	});
+
+	it('Save as functionality', () => {
+		cy.visit('/app/todo/view/report/Test%20Report%20Builder');
+		cy.get_page_title().should('contain', 'Test Report Builder');
+		cy.click_menu_button();
+		cy.click_toolbar_dropdown('Save%20As');
+		cy.wait(1000);
+
+		//Changes the name of the report from "Test Report Builder" to "Open Todos"
+		cy.get('.modal-dialog input[data-fieldname="name"]:visible').type('Open Todos');
+		cy.intercept('/api/method/frappe.desk.reportview.save_report').as('submit');
+		cy.click_modal_primary_button('Submit');
+		cy.wait('@submit');
+
+		//Checks if the title of the report gets renamed
+		cy.get_page_title().should('contain', 'Open Todos');
+	});
+
+	after(() => {
+		//Deletes the report "Test Report Builder"
+		cy.delete_doc('Report', 'Test Report Builder');
+    });
+});

--- a/erpnext_ui_tests/test_utils/todo.py
+++ b/erpnext_ui_tests/test_utils/todo.py
@@ -1,0 +1,15 @@
+import frappe
+
+def create_test_todo(description, assigned_by="Administrator", priority="Medium"):
+	return frappe.get_doc({
+		"doctype": "ToDo",
+		"description": description,
+		"priority": priority,
+		"assigned_by": assigned_by
+	}).insert(ignore_permissions=True)
+
+
+@frappe.whitelist()
+def create_todo_test_docs():
+	create_test_todo("test todo", priority="High")
+	create_test_todo("test todo", priority="Medium")


### PR DESCRIPTION
The above script does testing for the following:

1. Creates todos.
2. Creates new report of type "Report Builder".
3. Checks if creating a report with the same name throws error.
4. Checks if the report gets created with the required columns.
5. Checks for the pick column functionality and checks if the column picked gets added in the datatable.
6. Checks for the save as functionality and checks if the report gets renamed.
7. Deletes the created report.