### PR TITLE
test: Adding test script for checking if the quick entry form opens up for doctypes

### DIFF
--- a/cypress/integration/TF_02_framework/TS_14_quick_entry.js
+++ b/cypress/integration/TF_02_framework/TS_14_quick_entry.js
@@ -49,7 +49,7 @@ describe("Test quick entry for doctypes", () => {
 		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
 			.contains('Save')
 			.click({force: true});
-		cy.wait(1000);
+		cy.reload();
 		cy.get('.frappe-list').contains('Jenny Holmes');
 		cy.remove_doc('User', 'jenny_holmes@example.com');
 
@@ -65,7 +65,7 @@ describe("Test quick entry for doctypes", () => {
 		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
 			.contains('Save')
 			.click({force: true});
-		cy.wait(1000);
+		cy.reload();
 		cy.get('.frappe-list').contains('Table');
 		cy.remove_doc('Item', 'Table');
 
@@ -77,7 +77,7 @@ describe("Test quick entry for doctypes", () => {
 		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
 			.contains('Save')
 			.click({force: true});
-		cy.wait(1000);
+		cy.reload();
 		cy.get('.frappe-list').contains('Test Project');
 		cy.remove_doc('Project', 'PROJ-0002');
 	});

--- a/cypress/integration/TF_02_framework/TS_14_quick_entry.js
+++ b/cypress/integration/TF_02_framework/TS_14_quick_entry.js
@@ -46,9 +46,6 @@ describe("Test quick entry for doctypes", () => {
 		cy.set_input('first_name', 'Jenny Holmes');
 		cy.get_field('send_welcome_email', 'Check').uncheck();
 		cy.click_modal_primary_button('Save');
-		// cy.get('.modal-footer .standard-actions button.btn-modal-primary')
-		// 	.contains('Save')
-		// 	.click({force: true});
 		cy.reload();
 		cy.get('.frappe-list').contains('Jenny Holmes');
 		cy.remove_doc('User', 'jenny_holmes@example.com');
@@ -62,9 +59,6 @@ describe("Test quick entry for doctypes", () => {
 		cy.get('.modal-dialog [data-fieldname="item_group"] input:visible')
 			.type('{enter}');	
 		cy.click_modal_primary_button('Save');
-		// cy.get('.modal-footer .standard-actions button.btn-modal-primary')
-		// 	.contains('Save')
-		// 	.click({force: true});
 		cy.reload();
 		cy.get('.frappe-list').contains('Table');
 		cy.remove_doc('Item', 'Table');
@@ -74,12 +68,9 @@ describe("Test quick entry for doctypes", () => {
 		cy.get('.modal-dialog [data-fieldname="project_name"] input:visible')
 			.type('Test Project', {delay: 200});
 		cy.click_modal_primary_button('Save');
-		// cy.get('.modal-footer .standard-actions button.btn-modal-primary')
-		// 	.contains('Save')
-		// 	.click({force: true});
 		cy.wait(500);
 		cy.reload();
 		cy.get('.frappe-list').contains('Test Project');
-		cy.remove_doc('Project', 'PROJ-0002');
+		cy.remove_doc('Project', 'PROJ-0001');
 	});
 });

--- a/cypress/integration/TF_02_framework/TS_14_quick_entry.js
+++ b/cypress/integration/TF_02_framework/TS_14_quick_entry.js
@@ -46,9 +46,11 @@ describe("Test quick entry for doctypes", () => {
 		cy.set_input('first_name', 'Jenny Holmes');
 		cy.get_field('send_welcome_email', 'Check').uncheck();
 		//cy.click_modal_primary_button('Save');
+		cy.intercept('api/method/frappe.desk.form.save.savedocs').as('form-save');
 		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
 			.contains('Save')
 			.click({force: true});
+		cy.wait('@form-save');
 		cy.get('.frappe-list').contains('Jenny Holmes');
 		cy.remove_doc('User', 'jenny_holmes@example.com');
 
@@ -64,6 +66,7 @@ describe("Test quick entry for doctypes", () => {
 		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
 			.contains('Save')
 			.click({force: true});
+		cy.wait('@form-save');
 		cy.get('.frappe-list').contains('Table');
 		cy.remove_doc('Item', 'Table');
 
@@ -75,6 +78,7 @@ describe("Test quick entry for doctypes", () => {
 		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
 			.contains('Save')
 			.click({force: true});
+		cy.wait('@form-save');
 		cy.get('.frappe-list').contains('Test Project');
 		cy.remove_doc('Project', 'PROJ-0002');
 	});

--- a/cypress/integration/TF_02_framework/TS_14_quick_entry.js
+++ b/cypress/integration/TF_02_framework/TS_14_quick_entry.js
@@ -40,14 +40,14 @@ describe("Test quick entry for doctypes", () => {
 	});
 
 	it('Creating quick entries for following doctypes: User, Item and Project', () => {
-		cy.go_to_list('User');
-		cy.click_listview_primary_button('Add User');
-		cy.set_input('email', 'jenny_holmes@example.com');
-		cy.set_input('first_name', 'Jenny Holmes');
-		cy.get_field('send_welcome_email', 'Check').uncheck();
-		cy.click_modal_primary_button('Save');
-		cy.get('.frappe-list').contains('Jenny Holmes');
-		cy.remove_doc('User', 'jenny_holmes@example.com');
+		// cy.go_to_list('User');
+		// cy.click_listview_primary_button('Add User');
+		// cy.set_input('email', 'jenny_holmes@example.com');
+		// cy.set_input('first_name', 'Jenny Holmes');
+		// cy.get_field('send_welcome_email', 'Check').uncheck();
+		// cy.click_modal_primary_button('Save');
+		// cy.get('.frappe-list').contains('Jenny Holmes');
+		// cy.remove_doc('User', 'jenny_holmes@example.com');
 
 		cy.go_to_list('Item');
 		cy.click_listview_primary_button('Add Item');

--- a/cypress/integration/TF_02_framework/TS_14_quick_entry.js
+++ b/cypress/integration/TF_02_framework/TS_14_quick_entry.js
@@ -45,10 +45,10 @@ describe("Test quick entry for doctypes", () => {
 		cy.set_input('email', 'jenny_holmes@example.com');
 		cy.set_input('first_name', 'Jenny Holmes');
 		cy.get_field('send_welcome_email', 'Check').uncheck();
-		//cy.click_modal_primary_button('Save');
-		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
-			.contains('Save')
-			.click({force: true});
+		cy.click_modal_primary_button('Save');
+		// cy.get('.modal-footer .standard-actions button.btn-modal-primary')
+		// 	.contains('Save')
+		// 	.click({force: true});
 		cy.reload();
 		cy.get('.frappe-list').contains('Jenny Holmes');
 		cy.remove_doc('User', 'jenny_holmes@example.com');
@@ -61,10 +61,10 @@ describe("Test quick entry for doctypes", () => {
 		cy.wait(1000);
 		cy.get('.modal-dialog [data-fieldname="item_group"] input:visible')
 			.type('{enter}');	
-		//cy.click_modal_primary_button('Save');
-		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
-			.contains('Save')
-			.click({force: true});
+		cy.click_modal_primary_button('Save');
+		// cy.get('.modal-footer .standard-actions button.btn-modal-primary')
+		// 	.contains('Save')
+		// 	.click({force: true});
 		cy.reload();
 		cy.get('.frappe-list').contains('Table');
 		cy.remove_doc('Item', 'Table');
@@ -73,10 +73,11 @@ describe("Test quick entry for doctypes", () => {
 		cy.click_listview_primary_button('Add Project');
 		cy.get('.modal-dialog [data-fieldname="project_name"] input:visible')
 			.type('Test Project', {delay: 200});
-		//cy.click_modal_primary_button('Save');
-		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
-			.contains('Save')
-			.click({force: true});
+		cy.click_modal_primary_button('Save');
+		// cy.get('.modal-footer .standard-actions button.btn-modal-primary')
+		// 	.contains('Save')
+		// 	.click({force: true});
+		cy.wait(500);
 		cy.reload();
 		cy.get('.frappe-list').contains('Test Project');
 		cy.remove_doc('Project', 'PROJ-0002');

--- a/cypress/integration/TF_02_framework/TS_14_quick_entry.js
+++ b/cypress/integration/TF_02_framework/TS_14_quick_entry.js
@@ -40,14 +40,17 @@ describe("Test quick entry for doctypes", () => {
 	});
 
 	it('Creating quick entries for following doctypes: User, Item and Project', () => {
-		// cy.go_to_list('User');
-		// cy.click_listview_primary_button('Add User');
-		// cy.set_input('email', 'jenny_holmes@example.com');
-		// cy.set_input('first_name', 'Jenny Holmes');
-		// cy.get_field('send_welcome_email', 'Check').uncheck();
-		// cy.click_modal_primary_button('Save');
-		// cy.get('.frappe-list').contains('Jenny Holmes');
-		// cy.remove_doc('User', 'jenny_holmes@example.com');
+		cy.go_to_list('User');
+		cy.click_listview_primary_button('Add User');
+		cy.set_input('email', 'jenny_holmes@example.com');
+		cy.set_input('first_name', 'Jenny Holmes');
+		cy.get_field('send_welcome_email', 'Check').uncheck();
+		//cy.click_modal_primary_button('Save');
+		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
+			.contains('Save')
+			.click({force: true});
+		cy.get('.frappe-list').contains('Jenny Holmes');
+		cy.remove_doc('User', 'jenny_holmes@example.com');
 
 		cy.go_to_list('Item');
 		cy.click_listview_primary_button('Add Item');
@@ -57,7 +60,10 @@ describe("Test quick entry for doctypes", () => {
 		cy.wait(1000);
 		cy.get('.modal-dialog [data-fieldname="item_group"] input:visible')
 			.type('{enter}');	
-		cy.click_modal_primary_button('Save');
+		//cy.click_modal_primary_button('Save');
+		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
+			.contains('Save')
+			.click({force: true});
 		cy.get('.frappe-list').contains('Table');
 		cy.remove_doc('Item', 'Table');
 
@@ -65,7 +71,10 @@ describe("Test quick entry for doctypes", () => {
 		cy.click_listview_primary_button('Add Project');
 		cy.get('.modal-dialog [data-fieldname="project_name"] input:visible')
 			.type('Test Project', {delay: 200});
-		cy.click_modal_primary_button('Save');
+		//cy.click_modal_primary_button('Save');
+		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
+			.contains('Save')
+			.click({force: true});
 		cy.get('.frappe-list').contains('Test Project');
 		cy.remove_doc('Project', 'PROJ-0002');
 	});

--- a/cypress/integration/TF_02_framework/TS_14_quick_entry.js
+++ b/cypress/integration/TF_02_framework/TS_14_quick_entry.js
@@ -1,0 +1,72 @@
+//Doctypes for testing whether quick entry form opens for the respective doctypes
+const test_quick_entry_doctypes = [
+	"User",
+	"Project",
+	"Item", 
+	"Customer", 
+	"Supplier",
+	"Role", 
+	"Issue",
+	"UOM", 
+	"ToDo",
+	"Bank",
+	"Location",
+	"Item Price",
+	"Color",
+	"Country",
+	"Workstation",
+	"Comment",
+	"Batch"
+];
+
+describe("Test quick entry for doctypes", () => {
+	before(() => {
+		cy.login();
+	});
+
+	test_quick_entry_doctypes.forEach((doctype) => {
+		it(`should open quick entry ${doctype} form without any errors`, () => {
+			const slug = (name) => name.toLowerCase().replaceAll(" ", "-");
+			cy.visit(`/app/${slug(doctype)}`);
+
+			//Clicking on Add button to open the quick entry form 
+			//Also checking if the dialog opens and heading of the dialog consists of the doctype name
+			cy.get('.page-head button.primary-action')
+				.contains('Add '+doctype)
+				.click({force: true, scrollBehavior: false});
+			cy.get('.modal-dialog').should('exist');
+			cy.findByRole("heading", { level: 4 }).contains('New '+doctype);
+		});
+	});
+
+	it('Creating quick entries for following doctypes: User, Item and Project', () => {
+		cy.go_to_list('User');
+		cy.click_listview_primary_button('Add User');
+		cy.set_input('email', 'jenny_holmes@example.com');
+		cy.set_input('first_name', 'Jenny Holmes');
+		cy.get_field('send_welcome_email', 'Check').uncheck();
+		cy.click_modal_primary_button('Save');
+		cy.get('.frappe-list').contains('Jenny Holmes');
+		cy.remove_doc('User', 'jenny_holmes@example.com');
+
+		cy.go_to_list('Item');
+		cy.click_listview_primary_button('Add Item');
+		cy.set_input('item_code', 'Table');
+		cy.get('.modal-dialog [data-fieldname="item_group"] input:visible')
+			.type('Products', {delay: 300});
+		cy.wait(1000);
+		cy.get('.modal-dialog [data-fieldname="item_group"] input:visible')
+			.type('{enter}');	
+		cy.click_modal_primary_button('Save');
+		cy.get('.frappe-list').contains('Table');
+		cy.remove_doc('Item', 'Table');
+
+		cy.go_to_list('Project');
+		cy.click_listview_primary_button('Add Project');
+		cy.get('.modal-dialog [data-fieldname="project_name"] input:visible')
+			.type('Test Project', {delay: 200});
+		cy.click_modal_primary_button('Save');
+		cy.get('.frappe-list').contains('Test Project');
+		cy.remove_doc('Project', 'PROJ-0002');
+	});
+});

--- a/cypress/integration/TF_02_framework/TS_14_quick_entry.js
+++ b/cypress/integration/TF_02_framework/TS_14_quick_entry.js
@@ -46,11 +46,10 @@ describe("Test quick entry for doctypes", () => {
 		cy.set_input('first_name', 'Jenny Holmes');
 		cy.get_field('send_welcome_email', 'Check').uncheck();
 		//cy.click_modal_primary_button('Save');
-		cy.intercept('api/method/frappe.desk.form.save.savedocs').as('form-save');
 		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
 			.contains('Save')
 			.click({force: true});
-		cy.wait('@form-save');
+		cy.wait(1000);
 		cy.get('.frappe-list').contains('Jenny Holmes');
 		cy.remove_doc('User', 'jenny_holmes@example.com');
 
@@ -66,7 +65,7 @@ describe("Test quick entry for doctypes", () => {
 		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
 			.contains('Save')
 			.click({force: true});
-		cy.wait('@form-save');
+		cy.wait(1000);
 		cy.get('.frappe-list').contains('Table');
 		cy.remove_doc('Item', 'Table');
 
@@ -78,7 +77,7 @@ describe("Test quick entry for doctypes", () => {
 		cy.get('.modal-footer .standard-actions button.btn-modal-primary')
 			.contains('Save')
 			.click({force: true});
-		cy.wait('@form-save');
+		cy.wait(1000);
 		cy.get('.frappe-list').contains('Test Project');
 		cy.remove_doc('Project', 'PROJ-0002');
 	});


### PR DESCRIPTION
The above script tests the following:

1. Checks if the quick entry form opens up for the defined doctypes.
2. Checks if the quick entry form contains the doctypes name of the respective doctype.
3. Checks if using the quick entry form creates the entries for the following doctypes: Item, User, and Project.