### PR TITLE
test: Adding test script for "Trial Balance Report"

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -18,6 +18,7 @@
     "TF_05_selling/*",
     "TF_06_buying/*",
     "TF_07_stock/*",
-    "TF_08_manufacturing/*"
+    "TF_08_manufacturing/*",
+	"TF_09_reports/*"
   ]
 }

--- a/cypress/integration/TF_09_reports/TS_01_trial_balance.js
+++ b/cypress/integration/TF_09_reports/TS_01_trial_balance.js
@@ -1,0 +1,77 @@
+context('Trial Balance Report', () => {
+	before(() => {
+		cy.login();
+		cy.visit('/app');
+	});
+
+	it('Verifying debit and credit values for trial balance report', () => {
+		//Visiting the "Trial Balance" report
+		cy.visit('/app/query-report/Trial%20Balance');
+		cy.location('pathname').should('eq', '/app/query-report/Trial%20Balance');
+
+		//Checking company, fiscal year, from date and to date fields should not be empty
+		cy.get_input('company').should('not.be.empty');
+		cy.get_input('fiscal_year').should('not.be.empty');
+		cy.get_input('from_date').should('not.be.empty');
+		cy.get_input('to_date').should('not.be.empty');
+
+		//Checking if the from date starts with 1st of April
+		let fromdate;
+		cy.get_input('from_date').invoke('val').then(val => {
+			fromdate = val.substring(0, val.length -5);
+			expect(fromdate).to.contain('01-04');
+		});
+
+		//Checking if the to date is 31st of March
+		let todate;
+		cy.get_input('to_date').invoke('val').then(val => {
+			todate = val.substring(0, val.length -5);
+			expect(todate).to.contain('31-03');
+		});
+
+		//Checks the header of the report
+		cy.get_report_header().should('contain', 'Account')
+		.and('contain', 'Opening (Dr)')
+		.and('contain', 'Opening (Cr)')
+		.and('contain', 'Debit')
+		.and('contain', 'Credit')
+		.and('contain', 'Closing (Dr)')
+		.and('contain', 'Closing (Cr)');
+
+		//Checking if all the account heads are present in the report
+		cy.get_field('show_zero_values', 'Check').check();
+		cy.wait(2000);
+		cy.get_report_cell().should('contain', 'Application of Funds (Assets)');
+		cy.set_input_report('Source of Funds (Liabilities)');
+		cy.get_report_cell().should('contain', 'Source of Funds (Liabilities)');
+		cy.set_input_report('Income');
+		cy.get_report_cell().should('contain', 'Income');
+		cy.set_input_report('Expenses');
+		cy.get_report_cell().should('contain', 'Expenses');
+
+		//Checking if the total debit and credit values is equal in the report
+		let debit_col = '';
+		let debit = '';
+		cy.get_report_header().each(($cell) => {
+			if($cell.text().indexOf('Debit')!= -1){
+				debit_col = $cell.attr('data-col-index');
+				cy.set_input_report('Total');
+				cy.get(`.dt-row:last .dt-cell--col-${debit_col} span`)
+				.invoke('text').then((text) => {
+					debit = text;
+				});
+			}
+		})
+
+		let credit_col = '';
+		cy.get_report_header().each(($cell) => {
+			if($cell.text().indexOf('Credit')!= -1){
+				credit_col = $cell.attr('data-col-index');
+				cy.get(`.dt-row:last .dt-cell--col-${credit_col} span`)
+				.invoke('text').then((text) => {
+					expect(text.trim()).equal(debit)
+				});
+			}
+		})
+	});
+});

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -489,3 +489,15 @@ Cypress.Commands.add('click_print_button', () => {
 	cy.scrollTo('top', {ensureScrollable: false});
 	cy.get('.page-head button[data-original-title="Print"]').click({force: true});
 });
+
+Cypress.Commands.add('get_report_header', () => {
+	cy.get('.dt-row-header .dt-cell');
+});
+
+Cypress.Commands.add('get_report_cell', () => {
+	cy.get(`.datatable .dt-row`);
+});
+
+Cypress.Commands.add('set_input_report', (text) => {
+	cy.get('.dt-cell--col-1 .dt-filter').clear().type(`${text}`);
+});


### PR DESCRIPTION
The above script does testing for the following:

1. Visits the trial balance report and checks if the URL is correct.
2. Also checks if the fields company, from date, to date and fiscal year are not empty.
3. Checks if the from date is set to 1st of April.
4. Checks if the to date is set to 31st of March.
5. Checks if the required headers are present in the report.
6. Checks if the required account heads are present in the report.
7. Checks if the total debit and credit values are equal.