### PR TITLE
fix: Removing the code which checks for asset and liability accounting entries

### DIFF
--- a/cypress/integration/TF_04_accounts/TS_12_journal_entry_types.js
+++ b/cypress/integration/TF_04_accounts/TS_12_journal_entry_types.js
@@ -79,27 +79,7 @@ context("Journal Entry Types", () => {
         const todaysDate = Cypress.moment().format('DD-MM-YYYY');
         cy.get_input('posting_date').should('have.value', todaysDate);
 
-        //Checking if the accounting entires are of type "Asset" and "Liability" only
-        cy.grid_open_row('accounts', 3);
-        cy.get_input('account').click({force: true});
-        cy.click_link_button();
-		cy.contains('[data-fieldname="root_type"]:visible', /[Asset, Liability]/);
-        cy.go('back');
-        cy.grid_open_row('accounts', 18);
-        cy.get_input('account').click({force: true});
-        cy.click_link_button();
-		cy.contains('[data-fieldname="root_type"]:visible', /[Asset, Liability]/);
-        cy.go('back');
-        cy.grid_open_row('accounts', 35);
-        cy.get_input('account').click({force: true});
-        cy.click_link_button();
-		cy.contains('[data-fieldname="root_type"]:visible', /[Asset, Liability]/);
-        cy.go('back');
-
-        //Deleting all the rows and adding credit and debit entries
-        cy.scrollTo('top', {ensureScrollable: false});
-        cy.grid_delete_all();
-        cy.wait(5000);
+        //Adding credit and debit entries
         cy.grid_add_row('accounts');
         cy.set_link('accounts.account', 'Temporary Opening');
         cy.set_input('accounts.debit_in_account_currency', '50000');


### PR DESCRIPTION
Removing the code where the check was made for asset and liability in accounting entries for opening entry type of journal entry.

Refer: https://github.com/frappe/erpnext/pull/31439 

Whenever type for journal entry used to get selected as "Opening Entry", some default entries used to get displayed in the accounting entries table, but this behaviour was removed in the above mentioned PR, so changing the automation script according to the changes made in the above PR.