### PR TITLE
fix: fixing error in additional discount script by correcting template selection

### DIFF
--- a/cypress/integration/TF_04_accounts/TS_14_additional_discount.js
+++ b/cypress/integration/TF_04_accounts/TS_14_additional_discount.js
@@ -41,8 +41,8 @@ context('Additional Discount', () => {
 		cy.get_read_only('total_qty').should('contain', "1");
 		cy.get_read_only('total').should('contain', "₹ 100.00");
 
-		// Checking values without applying additin discount
-		cy.set_link('taxes_and_charges', 'Output GST Out-state');
+		// Checking values without applying additional discount
+		cy.set_link('taxes_and_charges', 'test Output GST Out-state');
 		cy.get_input('taxes.tax_amount').should('have.value', '18.00');
 		cy.get_read_only('total').should('contain', "118.00");
 		cy.get_read_only('total_taxes_and_charges').should('contain', "₹ 18.00");
@@ -100,8 +100,8 @@ context('Additional Discount', () => {
 		cy.get_read_only('total_qty').should('contain', "1");
 		cy.get_read_only('total').should('contain', "₹ 100.00");
 
-		// Checking values without applying additin discount
-		cy.set_link('taxes_and_charges', 'Output GST Out-state');
+		// Checking values without applying additional discount
+		cy.set_link('taxes_and_charges', 'test Output GST Out-state');
 		cy.get_input('taxes.tax_amount').should('have.value', '18.00');
 		cy.get_read_only('total').should('contain', "118.00");
 		cy.get_read_only('total_taxes_and_charges').should('contain', "₹ 18.00");


### PR DESCRIPTION
This PR fixes an error in the script by selecting the correct sales taxes and charges template. The previous template was not getting fetched as it was India-specific and it has been moved to the India Compliance app. 

So a test sales taxes and charges template is now selected in this script. 
