### PR TITLE
fix: exchange rate revaluation deletion fix

### DIFF
--- a/cypress/integration/TF_04_accounts/TS_08_exchange_rate_revaluation.js
+++ b/cypress/integration/TF_04_accounts/TS_08_exchange_rate_revaluation.js
@@ -168,7 +168,7 @@ context('Exchange Rate Creation Check', () => {
 	});
 	it('Deletion of created currency exchange rate', () => {
 		cy.visit('app/currency-exchange');
-		cy.clear_filter();
+		cy.clear_filters();
 		cy.click_listview_checkbox(0);
 		cy.click_dropdown_action('Actions', 'Delete');
 		cy.click_modal_primary_button('Yes');


### PR DESCRIPTION
This fix attempts to fix an error in the exchange rate revaluation script.

Currently, the script is breaking while clearing the filter when deleting the revaluation master, so have changed the command to clear the filters.