### PR TITLE
fix: date validation fix in sales invoice

### DIFF
--- a/cypress/integration/TF_05_selling/TS_04_sales_invoice.js
+++ b/cypress/integration/TF_05_selling/TS_04_sales_invoice.js
@@ -20,6 +20,7 @@ context('Sales Invoice Creation', () => {
 
 		cy.get_select('naming_series').should('have.value', 'ACC-SINV-.YYYY.-');
 		cy.get_input('customer').should('have.value', 'William Harris');
+		cy.get_field('set_posting_time', 'Check').check();
 		cy.get_input('posting_date').should('have.value', today_date);
 		cy.get_input('due_date').should('have.value', today_date);
 


### PR DESCRIPTION
This PR fix failing of Sales Invoice script by ensuring date time is editable

Previously this checkbox was not clicked due to which date validation was giving an error. 