### PR TITLE
fix: kill tests taking >5 minutes

### DIFF
--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -36,7 +36,7 @@ Cypress.on('window:before:load', (win) => {
 // taken from https://github.com/cypress-io/cypress/issues/5302#issuecomment-543959807
 let timeout_id;
 
-const test_timeout = 10 * 60 * 1000; // 10 minutes
+const test_timeout = 5 * 60 * 1000; // 5 minutes
 
 beforeEach(() => {
   timeout_id = setTimeout(() => {

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -31,3 +31,19 @@ Cypress.on('window:before:load', (win) => {
   cy.spy(win.console, 'log');
   cy.spy(win.console, 'warn');
 });
+
+
+// taken from https://github.com/cypress-io/cypress/issues/5302#issuecomment-543959807
+let timeout_id;
+
+const test_timeout = 10 * 60 * 1000; // 10 minutes
+
+beforeEach(() => {
+  timeout_id = setTimeout(() => {
+    throw new Error("Test took too long time.")
+  }, test_timeout);
+})
+
+afterEach(() => {
+  clearTimeout(timeout_id)
+})


### PR DESCRIPTION
AN attempt at finding why some tests get stuck... though I doubt this will help. 

