### PR TITLE
fix: removing write_off section validation

### DIFF
--- a/cypress/integration/TF_04_accounts/TS_09_multi_currency_accounting.js
+++ b/cypress/integration/TF_04_accounts/TS_09_multi_currency_accounting.js
@@ -86,7 +86,7 @@ context('Multi Currency Accounting', () => {
 				cy.get_read_only('rounded_total').should('contain', rateInCurrency);
 
 				cy.click_tab('Payments');
-				cy.click_section_head('write_off_section');
+				//cy.click_section_head('write_off_section');  //should only be visible for pos
 
 				cy.findByRole("tab", { name: "More Info" }).click();
 				cy.findByText('Accounting Details').scrollIntoView().should('be.visible');

--- a/cypress/integration/TF_05_selling/TS_16_advance_payment.js
+++ b/cypress/integration/TF_05_selling/TS_16_advance_payment.js
@@ -103,7 +103,7 @@ context('Advance Payment Check', () => {
 		cy.wait(500);
 
 		cy.click_tab('Payments');
-		cy.click_section_head('write_off_section');
+		//cy.click_section_head('write_off_section');  //should only be visible for pos
 		//cy.get_section('Write Off');
 		cy.findByText('Advance Payments').scrollIntoView().should('be.visible');
 		cy.get_section('Advance Payments');


### PR DESCRIPTION
This PR fixes the breaking scripts by removing the validations of write_off section.

Now the write_off section should be visible only for the pos invoices 

ref - https://github.com/frappe/erpnext/pull/32966