### PR TITLE
fix: corrected calculation as per precision in multi-currency, bank recon fix

### DIFF
--- a/cypress/integration/TF_04_accounts/TS_06_currency_exchange_rate.js
+++ b/cypress/integration/TF_04_accounts/TS_06_currency_exchange_rate.js
@@ -39,10 +39,11 @@ context('Currency and Exchange Rate Check', () => {
 				.then(val => {
 					const exRate = val;
 					cy.log("exchange rate " + exRate);
-					const roundedExchRate = Number(exRate).toFixed(2);
+					const roundedExchRate = Number(exRate).toFixed(3);  //set 3 as system setting shows precision of 3
 
-					const rate = (110000/exRate);
-					const roundedRate = Number(rate).toFixed(2);
+					//const rate = (110000/exRate);
+					const rate = (110000/roundedExchRate);
+					const roundedRate = Number(rate).toFixed(3);
 					cy.log("rounded rate " + roundedRate);
 					//const formattedRate = new Intl.NumberFormat().format(roundedRate);
 					const formattedRate = Number(roundedRate).toFixed(2).replace(/(\d)(?=(\d{2})+\d\.)/g, '$1,');
@@ -54,8 +55,8 @@ context('Currency and Exchange Rate Check', () => {
 					cy.get_input('rate').should('have.value', formattedRate);
 					cy.get_input('amount').should('have.value', formattedRate);
 
-					const total = (roundedRate * exRate);
-					const roundedTotal = Number(total).toFixed(2);
+					const total = (roundedRate * roundedExchRate);
+					const roundedTotal = Number(total).toFixed(3);
 					const formattedTotal = Number(roundedTotal).toFixed(2).replace(/(\d)(?=(\d{2})+\d\.)/g, '$1,');
 					//const formattedTotal = Intl.NumberFormat('en-IN').format(roundedTotal);
 					cy.log("total " + formattedTotal);

--- a/cypress/integration/TF_04_accounts/TS_09_multi_currency_accounting.js
+++ b/cypress/integration/TF_04_accounts/TS_09_multi_currency_accounting.js
@@ -54,11 +54,12 @@ context('Multi Currency Accounting', () => {
 			.then(val => {
 				const exRate = val;
 				cy.log(exRate);
+				const roundedExchRate = Number(exRate).toFixed(3);  //set 3 as system setting shows precision of 3
 
-				const roundedExchRate = Number(exRate).toFixed(2);
-
-				const rate = (110000/exRate);
-				const roundedRate = Number(rate).toFixed(2);
+				//const rate = (110000/exRate);
+				const rate = (110000/roundedExchRate);
+				const roundedRate = Number(rate).toFixed(3);
+				cy.log("rounded rate " + roundedRate);
 				//const formattedRate = new Intl.NumberFormat().format(roundedRate);
 				const formattedRate = Number(roundedRate).toFixed(2).replace(/(\d)(?=(\d{2})+\d\.)/g, '$1,');
 				cy.log("formatted rate " + formattedRate);
@@ -69,8 +70,8 @@ context('Multi Currency Accounting', () => {
 				cy.get_input('rate').should('have.value', formattedRate);
 				cy.get_input('amount').should('have.value', formattedRate);
 
-				const total = (roundedRate * exRate);
-				const roundedTotal = Number(total).toFixed(2);
+				const total = (roundedRate * roundedExchRate);
+				const roundedTotal = Number(total).toFixed(3);
 				//const formattedTotal = Intl.NumberFormat('en-IN').format(roundedTotal);
 				const formattedTotal = Number(roundedTotal).toFixed(2).replace(/(\d)(?=(\d{2})+\d\.)/g, '$1,');
 				cy.log("total " + formattedTotal);

--- a/cypress/integration/TF_04_accounts/TS_19_bank_reconciliation_tool.js
+++ b/cypress/integration/TF_04_accounts/TS_19_bank_reconciliation_tool.js
@@ -179,10 +179,12 @@ context('Semi-automatic Bank Reconciliation via Bank Reconciliation Tool', () =>
 		cy.save();
 		cy.set_today('bank_statement_from_date');
 		cy.set_today('bank_statement_to_date');
-		cy.save();
+		//cy.save();
 		cy.get_input('bank_statement_closing_balance').scrollIntoView().should('be.visible');
 		cy.get_input('bank_statement_closing_balance').click();
-		cy.set_input('bank_statement_closing_balance', '1500');
+		let x = Math.floor((Math.random() * 10000) + 1);
+		cy.set_input('bank_statement_closing_balance', x);
+		//cy.set_input('bank_statement_closing_balance', '1500');
 		cy.save();
 		cy.wait(500);
 


### PR DESCRIPTION
This PR attempts to fix the calculation part in multi-currency cases based on precision values. 

Also added a check to enter a random amount between a range in the bank recon tool's closing balance field so that it can re-run the 2nd/3rd attempt if fails. 