### PR TITLE
fix: fixes due to tab introduction on workstation form

### DIFF
--- a/cypress/integration/TF_03_masters/TS_05_workstations.js
+++ b/cypress/integration/TF_03_masters/TS_05_workstations.js
@@ -17,6 +17,7 @@ context("Workstation", () => {
         });
 		cy.go_to_list('Workstation');
 		cy.list_open_row(name);
+		cy.findByRole("tab", { name: "Operating Costs" }).click();
 		cy.get_read_only('hour_rate').should('contain','800');
 		cy.get_page_title().should('contain', name);
 


### PR DESCRIPTION
The workstation form is now bifurcated into tabs due to which some fields were not visible. 